### PR TITLE
Sort below core modules

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -22,7 +22,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <tab id="msp_common" translate="label" sortOrder="200">
+        <tab id="msp_common" translate="label" sortOrder="1000000">
             <label><![CDATA[<span class="msp-logo-config"></span><span>MageSpecialist</span>]]></label>
         </tab>
     </system>


### PR DESCRIPTION
As discussed and approved on magespecialist/m2-MSP_DevTools#24, this sorts the MageSpecialist section below the core configuration modules. This matches officially stated best practice.

The sort order value was incremented by one from the highest core section:
https://github.com/magento/magento2/blob/2.2.1/app/code/Magento/Backend/etc/adminhtml/system.xml#L16